### PR TITLE
Fix httpGET/httpPOST line endings, Fixed httpGET to return buffer

### DIFF
--- a/SIM900.cpp
+++ b/SIM900.cpp
@@ -79,17 +79,49 @@ int SIMCOM900::configandwait(char* pin)
   return 0;
 }
 
+/**
+ * SIMCOM900::read(char* buffer, int buffersize)
+ *
+ * Waits for data to be readable from the gsm module, reads data until
+ * no more is available or the buffer has been filled
+ *
+ * returns number of bytes read
+ *
+ */
 int SIMCOM900::read(char* result, int resultlength)
 {
 	char temp;
 	int i=0;
-	for(i=0; i<resultlength;i++){
-		temp=gsm.read();
-		if(temp>0){
-			Serial.print(temp);
-			result[i]=temp;
-		}
+
+	#ifdef DEBUG_ON
+	  Serial.print("Starting read..\nWaiting for Data..");
+	#endif
+	// Wait until we start receiving data
+	while(gsm.available()<1){
+	  delay(100);
+	  #ifdef DEBUG_ON
+	    Serial.print(".");
+      #endif
 	}
+
+	while(gsm.available()>0 && i<(resultlength-1)){
+		temp=_cell.read();
+		if(temp>0){
+			#ifdef DEBUG_ON
+			  Serial.print(temp);
+			#endif
+			result[i]=temp;
+			i++;
+		}
+		delay(1);
+	}
+
+	// Terminate the string
+	result[resultlength-1]='\0';
+
+	#ifdef DEBUG_ON
+	  Serial.println("\nDone..");
+	#endif
   return i;
 }
 
@@ -337,6 +369,11 @@ int SIMCOM900::getIMEI(char *imei)
     return 0;
   else  
     return 1;
+}
+
+int SIMCOM900::available()
+{
+  return _cell.available();
 }
 
 uint8_t SIMCOM900::read()

--- a/SIM900.h
+++ b/SIM900.h
@@ -24,6 +24,7 @@ class SIMCOM900 : public virtual GSM
 	char forceON();
     virtual int read(char* result, int resultlength);
 	virtual uint8_t read();
+	virtual int available();
     int readCellData(int &mcc, int &mnc, long &lac, long &cellid);
     void SimpleRead();
     void WhileSimpleRead();

--- a/inetGSM.cpp
+++ b/inetGSM.cpp
@@ -34,11 +34,11 @@ int InetGSM::httpGET(const char* server, int port, const char* path, char* resul
 	
   gsm.SimpleWrite("GET ");
   gsm.SimpleWrite(path);
-  gsm.SimpleWrite(" HTTP/1.0\nHost: ");
+  gsm.SimpleWrite(" HTTP/1.0\r\nHost: ");
   gsm.SimpleWrite(server);
-  gsm.SimpleWrite("\n");
+  gsm.SimpleWrite("\r\n");
   gsm.SimpleWrite("User-Agent: Arduino");
-  gsm.SimpleWrite("\n\n");
+  gsm.SimpleWrite("\r\n\r\n");
   gsm.SimpleWrite(end_c);
 
   switch(gsm.WaitResp(10000, 10, "SEND OK")){
@@ -51,11 +51,11 @@ int InetGSM::httpGET(const char* server, int port, const char* path, char* resul
   }
   
   
- delay(50);
+  delay(50);
   	#ifdef DEBUG_ON
 		Serial.println("DB:SENT");
 	#endif	
-  int res= gsm.read(result, resultlength);
+  int res = gsm.read(result, resultlength);
 
   //gsm.disconnectTCP();
   
@@ -90,17 +90,17 @@ int InetGSM::httpPOST(const char* server, int port, const char* path, const char
 	
   gsm.SimpleWrite("POST ");
   gsm.SimpleWrite(path);
-  gsm.SimpleWrite(" HTTP/1.1\nHost: ");
+  gsm.SimpleWrite(" HTTP/1.1\r\nHost: ");
   gsm.SimpleWrite(server);
-  gsm.SimpleWrite("\n");
-  gsm.SimpleWrite("User-Agent: Arduino\n");
-  gsm.SimpleWrite("Content-Type: application/x-www-form-urlencoded\n");
+  gsm.SimpleWrite("\r\n");
+  gsm.SimpleWrite("User-Agent: Arduino\r\n");
+  gsm.SimpleWrite("Content-Type: application/x-www-form-urlencoded\r\n");
   gsm.SimpleWrite("Content-Length: ");
   itoa(strlen(parameters),itoaBuffer,10);
   gsm.SimpleWrite(itoaBuffer);
-  gsm.SimpleWrite("\n\n");
+  gsm.SimpleWrite("\r\n\r\n");
   gsm.SimpleWrite(parameters);
-  gsm.SimpleWrite("\n\n");
+  gsm.SimpleWrite("\r\n\r\n");
   gsm.SimpleWrite(end_c);
  
   switch(gsm.WaitResp(10000, 10, "SEND OK")){


### PR DESCRIPTION
Fixing httpGET and httpPost to have the correct line endings:
- replace LF with CRLF in the HTTP request being sent

Fixing SIMCOM900::read() to allow httpGET to return a buffer with results
- added wait to allow time for the data to be received.
- added "while available" loop to read function to read only while available

This will have to be addressed again in the future to allow continued reading after the buffer is full.
