### PR TITLE
This fixes the pins not being initialized before using them.

### DIFF
--- a/GSM.cpp
+++ b/GSM.cpp
@@ -43,6 +43,10 @@ GSM::GSM()
 
 int GSM::begin(long baud_rate)
 {
+	 // Set pin modes
+	 pinMode(GSM_ON,OUTPUT);
+	 pinMode(GSM_RESET,OUTPUT);
+
 #ifdef UNO
      if (baud_rate==115200) {
           Serial.println("Don't use baudrate 115200 with Software Serial.\nAutomatically changed at 9600.");


### PR DESCRIPTION
Currently as far as I can tell GSM_RESET is not in use, but if we define it, we might as well initialize it.

This fixes issue mentioned here: https://code.google.com/p/gsm-shield-arduino/issues/detail?id=97
