### PR TITLE
Update HWSerial.cpp

### DIFF
--- a/HWSerial.cpp
+++ b/HWSerial.cpp
@@ -60,7 +60,7 @@ void HWSerial::flush()
 
 size_t HWSerial::print(const __FlashStringHelper *ifsh)
 {
-     const prog_char *p = (const prog_char *)ifsh;
+     const char PROGMEM  *p = (const char PROGMEM  *)ifsh;
      size_t n = 0;
      while (1) {
           unsigned char c = pgm_read_byte(p++);


### PR DESCRIPTION
Datatype prog_char has been deprecated since avr-libc version 1.8
