### PR TITLE
Fix for prog_char deprecated in avr-libc 

### DIFF
--- a/HWSerial.cpp
+++ b/HWSerial.cpp
@@ -60,7 +60,7 @@ void HWSerial::flush()
 
 size_t HWSerial::print(const __FlashStringHelper *ifsh)
 {
-     const prog_char *p = (const prog_char *)ifsh;
+     const char PROGMEM *p = (const char PROGMEM *)ifsh;
      size_t n = 0;
      while (1) {
           unsigned char c = pgm_read_byte(p++);


### PR DESCRIPTION
I replaced prog_char with PROGMEM, I am using this library on a MEGA board, so HWSerial is called.

I think that prog_char has been depreciated
